### PR TITLE
Add runner to WSV8DebuggerService & redefine new protocol method

### DIFF
--- a/lib/v8debug/V8Debugger.js
+++ b/lib/v8debug/V8Debugger.js
@@ -274,8 +274,6 @@ var V8Debugger = module.exports = function(tabId, v8service) {
         if (callback)
             this.$pending[msg.seq] = callback;
             
-        msg.runner = "node";
-        
         this.$service.debuggerCommand(this.tabId, msg.stringify());
     };
 

--- a/lib/v8debug/V8Debugger.js
+++ b/lib/v8debug/V8Debugger.js
@@ -270,6 +270,17 @@ var V8Debugger = module.exports = function(tabId, v8service) {
         this.$send(msg, callback);
     };
 
+    this.redefine = function(target, replace, callback) {
+        var msg = new V8Message("request");
+        msg.command = "redefine";
+        msg.arguments = {
+            target: target,
+            replace: replace
+        };
+
+        this.$send(msg, callback);
+    };
+
     this.$send = function(msg, callback) {
         if (callback)
             this.$pending[msg.seq] = callback;

--- a/lib/v8debug/WSV8DebuggerService.js
+++ b/lib/v8debug/WSV8DebuggerService.js
@@ -11,8 +11,9 @@ define(function(require, exports, module) {
 var Util = require("./util");
 var EventEmitter = Util.EventEmitter;
 
-var WSV8DebuggerService = module.exports = function(socket) {
+var WSV8DebuggerService = module.exports = function(socket, runner) {
     this.$socket = socket;
+    this.$runner = runner || "node";
     this.$state = "initialized";
     this.$onAttach = [];
 };
@@ -27,7 +28,7 @@ var WSV8DebuggerService = module.exports = function(socket) {
 
         this.$onAttach.push(callback);
         if (this.$state == "initialized") {
-            this.$socket.send(JSON.stringify({command: "DebugAttachNode", runner: "node"}));
+            this.$socket.send(JSON.stringify({command: "DebugAttachNode", runner: this.$runner}));
             this.$onMessageHandler = this.$onMessage.bind(this);
             this.$socket.on("message", this.$onMessageHandler);
             this.$state = "connecting";
@@ -65,7 +66,7 @@ var WSV8DebuggerService = module.exports = function(socket) {
         this.$socket.send(JSON.stringify({
             command: "debugNode",
             pid: this.pid,
-            runner: "node",
+            runner: this.$runner,
             body: JSON.parse(v8Command)
         }));
     };


### PR DESCRIPTION
Add runner to WSV8DebuggerService:

I need it to differ java debug messages from node debug messages
e.g. saying this is a debug message for the "java" runner

Redefine:
Reload source after change - needed in Java code hot swapping